### PR TITLE
Add script to generate certs; support WSL for e2e-tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ cloud-resource-manager/cmd/crmserver/envoy/*
 controller/.influxdb/*
 controller/envoy/*
 dump.rdb
+tls/out

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ build: check-vers
 	make -C edgeproto
 	make -C testgen
 	make -C d-match-engine
+	(cd tls; ./gen-test-certs.sh)
 	go build ./...
 	go vet ./...
 

--- a/tls/gen-test-certs.sh
+++ b/tls/gen-test-certs.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+CANAME=test-ca
+SERVERNAME=test-server
+
+if [ -e out/${CANAME}.crt ]; then
+    echo "certs exist"
+    exit 0
+fi
+
+echo "generating CA..."
+certstrap init --common-name ${CANAME} --passphrase ""
+
+echo "generating server cert"
+certstrap request-cert --domain ${SERVERNAME} --passphrase ""
+
+echo "signing server cert"
+certstrap sign --CA ${CANAME} ${SERVERNAME}


### PR DESCRIPTION
Test certs were removed as part of security cleaning, add a script to create them without checking them in.

WSL (windows subsystem linux) support added for e2e-tests. The only change was to set the host.docker.internal correctly, since by default it gets set to the windows internal interface, not the WSL interface. This is needed for processes inside containers to reach processes running outside the container (in WSL linux, not in windows).